### PR TITLE
Updating default local consul address

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,6 @@ to a UI screen which shows registered services.
 ### Attaching configured services to your consul instance
 
 Once you are running consul and have set up the dependency files, just run `consulship` in the root alongside your `configs` and `.consulship` directory!
+
+We assume that you are running consul on `localhost:8500`, if this is not the case you may override it by passing `LOCAL_CONSUL_ADDR={your IP:PORT}` as an environment
+variable on the command, your command will then become `LOCAL_CONSUL_ADDR={your IP:PORT} consulship`

--- a/main.go
+++ b/main.go
@@ -14,6 +14,8 @@ type ConsulConfig struct {
 	Address string `json:"address"`
 }
 
+const defaultLocalConsulAddr = "localhost:8500"
+
 var (
 	consulByEnv = make(map[string]*api.Client)
 
@@ -30,11 +32,14 @@ func init() {
 }
 
 func createConsulClients(consulEnvConfig []ConsulConfig) {
-	consulAddr := os.Getenv("CONSUL_ADDR")
+	localConsulAddr := os.Getenv("LOCAL_CONSUL_ADDR")
+	if localConsulAddr == "" {
+		localConsulAddr = defaultLocalConsulAddr
+	}
 
 	consulEnvConfig = append(consulEnvConfig, ConsulConfig{
 		Name:    "local",
-		Address: consulAddr,
+		Address: localConsulAddr,
 	})
 
 	var err error


### PR DESCRIPTION
Defaults to localhost:8500.

Fixes an issue where consulship fails silently for local dependencies.