### PR TITLE
Use Goreleaser for releasing

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,9 @@
+builds:
+  - binary: consulship
+    goos:
+      - darwin
+      - linux
+    goarch:
+      - amd64
+    env:
+      - CGO_ENABLED=0


### PR DESCRIPTION
Added goreleaser config to handle releases, initially for `linux` and `darwin` 64 bit machines. Can be extended in future for further reach.

Once merged, we can then update to CircleCI and release based on tags automatically through CI.