### PR TITLE
Do not use duplicate IDs when registering multitag services

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+build:
+	go build
+
 build-linux:
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build
 

--- a/dependency_test.go
+++ b/dependency_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"sort"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -195,6 +196,11 @@ func TestMergeDepsConfig(t *testing.T) {
 
 	for _, test := range mergeTests {
 		got, err := mergeDepConfigs(test.base, test.local)
+
+		sort.Slice(got, func(i, j int) bool {
+			return got[i].Name < got[i].Name
+		})
+
 		if err != nil {
 			assert.Equal(t, test.err.Error(), err.Error(), test.name)
 		} else {

--- a/register.go
+++ b/register.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"log"
 
 	"github.com/hashicorp/consul/api"
@@ -42,8 +43,12 @@ func registerRemoteService(dep DependencyConfig) error {
 		if address == "" {
 			address = service.Address
 		}
+		name := dep.Name
+		if tag != "" {
+			name = fmt.Sprintf("%s-%s", name, tag)
+		}
 		reg := &api.AgentServiceRegistration{
-			ID:      dep.Name,
+			ID:      name,
 			Name:    dep.Name,
 			Port:    service.ServicePort,
 			Address: address,


### PR DESCRIPTION
This change adds tag to consul ID if tag is not empty. This is to make sure that we do not try to register the same service with the same ID multiple times as that would not work.